### PR TITLE
Flexible broadcast handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,53 +1,37 @@
 name: Publish Binaries on Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - v*
 
 jobs:
   release-kasautil:
     name: Release kasautil
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-            artifact: kasautil-linux-amd64
-          - goos: linux
-            goarch: arm
-            goarm: 6
-            artifact: kasautil-linux-arm6
-          - goos: linux
-            goarch: arm
-            goarm: 7
-            artifact: kasautil-linux-arm7
-          - goos: darwin
-            goarch: amd64
-            artifact: kasautil-darwin-amd64
     steps:
       - uses: actions/checkout@v2
-      - name: Build ${{ matrix.artifact }}
+      - name: Build kasautil
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
         run: |
-          go build -o ${{ matrix.artifact }} ./cmd/kasautil/
-          shasum -a 256 ${{ matrix.artifact }} >> SHA256SUM.txt
-      - name: Upload ${{ matrix.artifact }} to Release
-        uses: svenstaro/upload-release-action@v2
+          echo -n > SHA256SUM.txt
+          env GOOS=darwin GOARCH=amd64 go build -o kasautil-darwin-amd64 ./cmd/kasautil/
+          env GOOS=linux GOARCH=amd64 go build -o kasautil-linux-amd64 ./cmd/kasautil/
+          env GOOS=linux GOARCH=arm GOARM=6 go build -o kasautil-linux-arm6 ./cmd/kasautil/
+          env GOOS=linux GOARCH=arm GOARM=7 go build -o kasautil-linux-arm7 ./cmd/kasautil/
+          shasum -a 256 kasautil-* >> SHA256SUM.txt
+      - name: Release kasautil
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.artifact }}
-          asset_name: ${{ matrix.artifact }}
-          tag: ${{ github.ref }}
-          overwrite: true
-      - name: Upload SHA256SUM to Release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: SHA256SUM.txt
-          asset_name: SHA256SUM.txt
-          tag: ${{ github.ref }}
-          overwrite: true
+          files: |
+            kasautil-darwin-amd64
+            kasautil-linux-amd64
+            kasautil-linux-arm6
+            kasautil-linux-arm7
+            SHA256SUM.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+
+# Ignore locally-built binaries.
+kasautil-*

--- a/README.md
+++ b/README.md
@@ -5,6 +5,27 @@ your local network.
 
 ## Command Line
 
+Full `kasautil` options:
+
+```console
+$ kasautil
+NAME:
+   kasautil - Control Kasa devices on the local network
+
+USAGE:
+   kasautil [global options] command [command options] [arguments...]
+
+COMMANDS:
+   list, ls  List kasa devices on the local network.
+   off       Set a kasa device to "off"
+   on        Set a kasa device to "on"
+   help, h   Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --help, -h  show help (default: false)
+
+```
+
 You may discover Kasa devices locally with the `list` command of `kasautil`.
 
 ```console
@@ -23,5 +44,31 @@ $ kasautil off 10.24.6.14:9999
 $ kasautil list
 Address          Alias             State
 10.24.6.14:9999  ADSL Modem        Off
+10.23.6.15:9999  Living Room Lamp  On
+```
+
+### Broadcast Issues
+
+Discovery relies on UDP packets sent to a broadcast address. This can fail when
+the host on which `kasautil` has many network interfaces or multiple network
+addresses on a single interface. This is known to happen on Linux with a single
+interface on multiple VLANs, for example.
+
+In this case, you have two options:
+
+1. Specify a local address using `-L` / `--local` on the correct network from
+   which to send the Kasa request
+
+2. Specify a device or broadcast address using `-d` / `--device` / `--discover`
+   on the correct network to which the Kasa request should be sent
+
+```console
+$ kasautil list -L 10.24.6.15:54321
+Address          Alias             State
+10.24.6.14:9999  ADSL Modem        On
+10.23.6.15:9999  Living Room Lamp  On
+$ kasautil list -d 10.24.6.255:9999
+Address          Alias             State
+10.24.6.14:9999  ADSL Modem        On
 10.23.6.15:9999  Living Room Lamp  On
 ```

--- a/cmd/kasautil/main.go
+++ b/cmd/kasautil/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/urfave/cli/v2"
@@ -11,16 +13,44 @@ import (
 	"github.com/cfunkhouser/kasa"
 )
 
-func setState(c *cli.Context, state bool) error {
-	addr := c.Args().First()
-	if addr == "" {
-		return cli.Exit("address is required", 1)
+func parseAddr(addr string) (*net.UDPAddr, error) {
+	s := strings.Split(addr, ":")
+	if len(s) != 2 {
+		return nil, fmt.Errorf("not sure what to do with %q, specify ip:port", addr)
 	}
-	raddr, err := net.ResolveUDPAddr("udp4", addr)
+	port, err := strconv.Atoi(s[1])
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("not sure what to do with port %q, specify ip:port", s[1])
 	}
-	return kasa.SetRelayState(c.Context, raddr, state)
+	ip := net.ParseIP(s[0])
+	if ip == nil {
+		return nil, fmt.Errorf("not sure what to do with IP %q, specify ip:port", s[0])
+	}
+	return &net.UDPAddr{
+		IP:   net.ParseIP(s[0]),
+		Port: port,
+	}, nil
+}
+
+func parseAddrs(c *cli.Context) (daddr, laddr *net.UDPAddr, err error) {
+	daddr, err = parseAddr(c.String("device"))
+	if err != nil {
+		return
+	}
+	if l := c.String("local"); l != "" {
+		if laddr, err = parseAddr(l); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func setState(c *cli.Context, state bool) error {
+	daddr, laddr, err := parseAddrs(c)
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	return kasa.SetRelayState(c.Context, daddr, laddr, state)
 }
 
 func main() {
@@ -30,10 +60,27 @@ func main() {
 		Commands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "l"},
+				Aliases: []string{"ls"},
 				Usage:   "List kasa devices on the local network.",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:    "device",
+						Aliases: []string{"d", "discover"},
+						Usage:   "Broadcast ip:port target for discovery requests",
+						Value:   "255.255.255.255:9999",
+					},
+					&cli.StringFlag{
+						Name:    "local",
+						Usage:   "Local ip:port from which to send discovery requests",
+						Aliases: []string{"L"},
+					},
+				},
 				Action: func(c *cli.Context) error {
-					infos, err := kasa.Discover(c.Context)
+					daddr, laddr, err := parseAddrs(c)
+					if err != nil {
+						return cli.Exit(err, 1)
+					}
+					infos, err := kasa.GetSystemInformation(c.Context, daddr, laddr, false)
 					if err != nil {
 						return err
 					}

--- a/cmd/kasautil/main.go
+++ b/cmd/kasautil/main.go
@@ -53,6 +53,14 @@ func setState(c *cli.Context, state bool) error {
 	return kasa.SetRelayState(c.Context, daddr, laddr, state)
 }
 
+var commonFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "local",
+		Usage:   "Local ip:port from which to send discovery requests",
+		Aliases: []string{"L"},
+	},
+}
+
 func main() {
 	app := &cli.App{
 		Name:  "kasautil",
@@ -62,19 +70,12 @@ func main() {
 				Name:    "list",
 				Aliases: []string{"ls"},
 				Usage:   "List kasa devices on the local network.",
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:    "device",
-						Aliases: []string{"d", "discover"},
-						Usage:   "Broadcast ip:port target for discovery requests",
-						Value:   "255.255.255.255:9999",
-					},
-					&cli.StringFlag{
-						Name:    "local",
-						Usage:   "Local ip:port from which to send discovery requests",
-						Aliases: []string{"L"},
-					},
-				},
+				Flags: append(commonFlags, &cli.StringFlag{
+					Name:    "device",
+					Aliases: []string{"d", "discover"},
+					Usage:   "Broadcast ip:port target for discovery requests",
+					Value:   "255.255.255.255:9999",
+				}),
 				Action: func(c *cli.Context) error {
 					daddr, laddr, err := parseAddrs(c)
 					if err != nil {
@@ -102,17 +103,27 @@ func main() {
 				},
 			},
 			{
-				Name:      "off",
-				Usage:     `Set a kasa device to "off"`,
-				ArgsUsage: "[address]",
+				Name:  "off",
+				Usage: `Set a kasa device to "off"`,
+				Flags: append(commonFlags, &cli.StringFlag{
+					Name:     "device",
+					Aliases:  []string{"d"},
+					Required: true,
+					Usage:    "ip:port of Kasa device",
+				}),
 				Action: func(c *cli.Context) error {
 					return setState(c, false)
 				},
 			},
 			{
-				Name:      "on",
-				Usage:     `Set a kasa device to "on"`,
-				ArgsUsage: "[address]",
+				Name:  "on",
+				Usage: `Set a kasa device to "on"`,
+				Flags: append(commonFlags, &cli.StringFlag{
+					Name:     "device",
+					Aliases:  []string{"d"},
+					Required: true,
+					Usage:    "ip:port of Kasa device",
+				}),
 				Action: func(c *cli.Context) error {
 					return setState(c, true)
 				},


### PR DESCRIPTION
Refactor calling functions to also accept a local address. Also remove now mostly useless `Discover` function.

Remove call to `net.ResolveUDPAddr` in favor of direct `net.UDPAddr` construction.

Unexport `receive()` function.

Update `kasautil` options to consume these changes, and document.